### PR TITLE
[nrf fromtree] fix: potential memory leak in merge_patch() (#611)

### DIFF
--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -1365,6 +1365,7 @@ static cJSON *merge_patch(cJSON *target, const cJSON * const patch, const cJSON_
             replacement = merge_patch(replace_me, patch_child, case_sensitive);
             if (replacement == NULL)
             {
+                cJSON_Delete(target);
                 return NULL;
             }
 


### PR DESCRIPTION
Backport an upstream fix to deal with a static analysis error.

This seems unlikely to happen in practice based on the discussion
here:

https://github.com/DaveGamble/cJSON/commit/f50dafc7d0bfd4f45449ab5665bfea831a82f2eb

But it also looks like upstream has no plans to do another release
with the fix, so let's just get it into NCS.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>
(cherry picked from commit f50dafc7d0bfd4f45449ab5665bfea831a82f2eb)